### PR TITLE
Fix variable reference in AIC/BIC calculation

### DIFF
--- a/07-survival/code.R
+++ b/07-survival/code.R
@@ -176,9 +176,9 @@ aicres.lev <- data.frame(
 aicres.lev %>% arrange(AIC)
 
 aicres.obs <- data.frame(
-  model = names(fit.survHE.RFS.lev$models), 
-  AIC = fit.survHE.RFS.lev$model.fitting$aic,
-  BIC = fit.survHE.RFS.lev$model.fitting$bic
+  model = names(fit.survHE.RFS.obs$models), 
+  AIC = fit.survHE.RFS.obs$model.fitting$aic,
+  BIC = fit.survHE.RFS.obs$model.fitting$bic
 )
 aicres.obs %>% arrange(AIC)
 


### PR DESCRIPTION
Corrected the data source from fit.survHE.RFS.lev to fit.survHE.RFS.obs when creating the aicres.obs data frame, ensuring the correct model statistics are used.